### PR TITLE
Added automatic dice rolling

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -1,0 +1,64 @@
+function getDice(table) {
+	var possibleDiceCells = $(table).find('th:first-child');
+	var diceText = undefined;
+	possibleDiceCells.each(function () {
+		var text = $(this).text().trim();
+		if (/^d\d+$/.test(text)) {
+			diceText = text;
+			return false;
+		}
+	});
+	
+	if (diceText === undefined)
+		return undefined;
+	
+	return parseInt(diceText.replace('d', ''));
+}
+
+function rollDice(maxValue) {
+	return Math.floor(Math.random() * maxValue) + 1;
+}
+
+function rollTable(table) {
+	var maxValue = getDice(table);
+	var value = rollDice(maxValue);
+	var output = '???';
+	
+	table.find('tr').each(function () {
+		if ($(this).find('th').length > 0)
+			return true;
+		
+		var numText = $(this).find('td').first().text().split('-');
+		var min = parseInt(numText[0]);
+		var max = numText.length > 1 ? parseInt(numText[1]) : min;
+		if (min == 0) 
+			min = maxValue;
+		if (max == 0) 
+			max = maxValue;
+		
+		if (value < min || value > max)
+			return true;
+
+		output = $(this).find('td').last().text();
+		return false;
+	});
+
+	return output;
+}
+
+function rollLink(link) {
+	var table = $(link).closest('table');
+	alert(rollTable(table));
+}
+
+function setupDiceTables() {
+	$('table').each(function () {
+		// only dice tables should be modified
+		if (getDice(this) === undefined)
+			return true;
+		
+		var cell = $(this).find('tr').first().find('th').last();
+		cell.css('position', 'relative');
+		cell.append('<a href="#" onclick="rollLink(this); return false;" style="position:absolute; right:-32px">roll</a>');
+	});
+}

--- a/dice.js
+++ b/dice.js
@@ -44,7 +44,7 @@ function rollTable(table) {
 		if (value < min || value > max)
 			return true;
 
-		output = $(this).find('td').last().text();
+		output = $(this).find('td').last().text().trim();
 		return false;
 	});
 

--- a/dice.js
+++ b/dice.js
@@ -1,18 +1,23 @@
 function getDice(table) {
+	var diceCell = getDiceCell(table);
+	if (diceCell === undefined)
+		return undefined;
+	
+	var diceText = diceCell.text().trim();
+	return parseInt(diceText.replace('d', ''));
+}
+
+function getDiceCell(table) {
 	var possibleDiceCells = $(table).find('th:first-child');
-	var diceText = undefined;
+	var cell = undefined;
 	possibleDiceCells.each(function () {
 		var text = $(this).text().trim();
 		if (/^d\d+$/.test(text)) {
-			diceText = text;
+			cell = $(this);
 			return false;
 		}
 	});
-	
-	if (diceText === undefined)
-		return undefined;
-	
-	return parseInt(diceText.replace('d', ''));
+	return cell;
 }
 
 function rollDice(maxValue) {
@@ -43,7 +48,7 @@ function rollTable(table) {
 		return false;
 	});
 
-	return output;
+	return value + ':  ' + output;
 }
 
 function rollLink(link) {
@@ -54,11 +59,11 @@ function rollLink(link) {
 function setupDiceTables() {
 	$('table').each(function () {
 		// only dice tables should be modified
-		if (getDice(this) === undefined)
+		var diceCell = getDiceCell(this);
+		if (diceCell === undefined)
 			return true;
 		
-		var cell = $(this).find('tr').first().find('th').last();
-		cell.css('position', 'relative');
-		cell.append('<a href="#" onclick="rollLink(this); return false;" style="position:absolute; right:-32px">roll</a>');
+		var diceText = diceCell.text().trim();
+		diceCell.html('<a href="#" onclick="rollLink(this); return false;">' + diceText + '</a>');
 	});
 }

--- a/index.html
+++ b/index.html
@@ -15468,6 +15468,7 @@ Use <a href="#traps">these charts</a> to determine attack bonus, save DC, and da
 		<script src="jquery-1.12.0.min.js"></script>
 		<script src="jquery-ui.min.js"></script>
 		<script src="jquery.tocify.min.js""></script>
+		<script src="dice.js""></script>
 		<script>
 			       //Executes your code when the DOM is ready.  Acts the same as $(document).ready().
               $(function() {
@@ -15476,6 +15477,9 @@ Use <a href="#traps">these charts</a> to determine attack bonus, save DC, and da
 					 }).data("toc-tocify");
                   //Calls the tocify method on your HTML div.
                   $("#toc").tocify();				 
+
+                  //Adds "roll" link to each table containing dice values
+                  setupDiceTables();				  
               });
 		</script>
 	<script>


### PR DESCRIPTION
A link is shown next to each "dice" table that automatically rolls a value from it (based on the dice specified at the top, and the dice values specified in each row). This can be previewed here:

http://ftwinston.github.io/5edmscreen/

It's not terribly fancy looking - the results are just shown in an alert dialog - but it does allow for rolling on multiple tables at once, e.g. for generating dungeon traps - paste the following into the console to randomly roll on all 3 dungeon trap generation tables:

```
alert('When a trigger is ' + rollTable($('#randomtraptrigger').next('table')) + ', a '
+ rollTable($('#randomtrapseverity').next('table')) + ' trap is activated:\n'
+ rollTable($('#randomtrapeffect').next('table')));
```
