### PR TITLE
Reduce line-height in the ToC

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,9 @@
 				width: 100%;
 				margin: 0px 0px 20px 0px;
 			}
-
+			.tocify li.tocify-item {
+				line-height: 20px;
+			}
 
 		</style>
 <script language="JavaScript">


### PR DESCRIPTION
Currently it takes up a lot of height, scrolling through the screen causes the scrollbar to flash in view because of the height.
