### PR TITLE
Change for the short/long rest section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3641,7 +3641,7 @@ function findInPage(str) {
 							</li>
 						</ul>
 						<b>Full Text:</b>
-						A short rest is a period of downtime, at least 1 hour long, during which a character does nothing more strenuous that eating, drinking, reading, and tending to wounds. A character can spend one or more Hit Dice at the end of a short rest, up to the character's maximum number of Hit Dice, which is equal to the character's level. For each Hit Dice spent in this way, the player rolls the die and adds the character's Constitution modifier to it. The character regains hit points equal to the total. The player can decide to spend an additional Hit Die after each roll. A character regains some spent Hit Dice upon finishing a long rest, as explained below.
+						<p>A short rest is a period of downtime, at least 1 hour long, during which a character does nothing more strenuous that eating, drinking, reading, and tending to wounds. A character can spend one or more Hit Dice at the end of a short rest, up to the character's maximum number of Hit Dice, which is equal to the character's level. For each Hit Dice spent in this way, the player rolls the die and adds the character's Constitution modifier to it. The character regains hit points equal to the total. The player can decide to spend an additional Hit Die after each roll. A character regains some spent Hit Dice upon finishing a long rest, as explained below.</p>
 					
 					
 						<b>Long Rest:</b>
@@ -3658,9 +3658,9 @@ function findInPage(str) {
 							</li>
 						</ul>
 						<b>Full Text:</b>
-						A long rest is a period of extended downtime, at least 8 hours long, during which a character sleeps or performs light activity: reading, talking, eating or standing watch for no more than 2 hours. If the rest in interrupted by a period of strenuous activity - at least 1 hour of waking, fighting, casting spells, or similar adventuring activity - the characters must begin the rest again to gain any benefit from it. 
+						<p>A long rest is a period of extended downtime, at least 8 hours long, during which a character sleeps or performs light activity: reading, talking, eating or standing watch for no more than 2 hours. If the rest in interrupted by a period of strenuous activity - at least 1 hour of waking, fighting, casting spells, or similar adventuring activity - the characters must begin the rest again to gain any benefit from it.
 						At the end of a long rest, a character regains all lost hit points. The character also regains spent Hit Dice, up to a number of dice equal to half of the character's total number of them. For example, if a character has eight Hit Dice, he or she can regain four spent Hit Dice upon finishing a long rest.
-						A character can't benefit from more than one long rest in a 24-hour period, and a character must have at least 1 hit point at the start of the rest to gain its benefits.
+							A character can't benefit from more than one long rest in a 24-hour period, and a character must have at least 1 hit point at the start of the rest to gain its benefits.</p>
 					
 				<br>
 				<h2 id="weather">


### PR DESCRIPTION
Change for the short/long rest section so that the long rest title is on its own line and not bunched in with the short rest description.